### PR TITLE
Support `git clone`

### DIFF
--- a/try
+++ b/try
@@ -129,12 +129,15 @@ commit() {
         then # whiteout file
             rm "${changed_file#$SANDBOX_DIR/upperdir}"
         elif [ -f "$changed_file" ]
-	then # normal file
-            cp "$changed_file" "${changed_file#$SANDBOX_DIR/upperdir}"
+	    then # normal file
+            dest_path="${changed_file#$SANDBOX_DIR/upperdir}"
+            dirname=$(dirname "$dest_path")
+            mkdir -p "$dirname"
+            cp "$changed_file" "$dest_path"
         fi
 	
         if [ $? -ne 0 ]
-	then
+	    then
 	    # TODO collect errors and summarize later
             printf "couldn't commit $changed_file\n"
             exit 1

--- a/try
+++ b/try
@@ -105,9 +105,9 @@ summary() {
         echo "Changes detected in the following files:"
         echo
         echo "$changed_files"
-    return 0
+        return 0
     else
-    return 1
+        return 1
     fi
 }
 

--- a/try
+++ b/try
@@ -32,6 +32,11 @@ try() {
 # TODO we may not need to ignore ALL of these (paltform dependent?)
 ls / | grep -v -e proc -e dev -e proj -e run -e sys -e snap -e swap.img | xargs -I '{}' mount -t overlay overlay -o lowerdir=/'{}',upperdir="$SANDBOX_DIR"/upperdir/'{}',workdir="$SANDBOX_DIR"/workdir/'{}' "$SANDBOX_DIR"/temproot/'{}'
 
+## Bind the udev mount so that the containerized process has access to /dev
+## KK 2023-05-06 Are there any secutiry/safety implications by binding the whole /dev?
+##               Maybe we just want to bind a few files in it like /dev/null, /dev/zero?
+mount --rbind /dev "$SANDBOX_DIR/temproot/dev"
+
 unshare --root="$SANDBOX_DIR/temproot" /bin/bash "$chroot_executable"
 EOF
 

--- a/try
+++ b/try
@@ -97,6 +97,7 @@ summary() {
     fi
     
     # TODO let people control what's ignored
+    # We don't include directories here since that would be too verbose for the summary.
     changed_files=$(find "$SANDBOX_DIR/upperdir/" -type f -or \( -type c -size 0 \) | grep -v -e .rkr -e Rikerfile)
 
     if [ "$changed_files" ]
@@ -116,25 +117,22 @@ summary() {
 ################################################################################
 
 commit() {
-    if ! [ "$changed_files" ]
-    then
-        changed_files=$(find "$SANDBOX_DIR/upperdir/" -type f -o \( -type c -size 0 \) -o -type d | grep -v -e .rkr -e Rikerfile)
-    fi
+    # This is different from the one in summary because it also includes all directories.
+    # TODO: Could be made more efficient by only appending directories to the already computed
+    #       changed_files from summary.
+    changed_files=$(find "$SANDBOX_DIR/upperdir/" -type f -o \( -type c -size 0 \) -o -type d | grep -v -e .rkr -e Rikerfile)
 
     while IFS= read -r changed_file; do
-        if [ -d "$changed_file" ] && ! [ -d "${changed_file#$SANDBOX_DIR/upperdir}" ]
+        local_file="${changed_file#$SANDBOX_DIR/upperdir}"
+        if [ -d "$changed_file" ] && ! [ -d "${local_file}" ]
         then # new directory
-            mkdir "${changed_file#$SANDBOX_DIR/upperdir}"
+            mkdir "${local_file}"
         elif [ -c "$changed_file" ] && ! [ -s "$changed_file" ]
         then # whiteout file
-            rm "${changed_file#$SANDBOX_DIR/upperdir}"
+            rm "${local_file}"
         elif [ -f "$changed_file" ]
         then # normal file
-            dest_path="${changed_file#$SANDBOX_DIR/upperdir}"
-            ## Create the directory if neede dbefore copying the file
-            dirname=$(dirname "$dest_path")
-            mkdir -p "$dirname"
-            cp "$changed_file" "$dest_path"
+            cp "$changed_file" "${local_file}"
         fi
     
         if [ $? -ne 0 ]

--- a/try
+++ b/try
@@ -67,16 +67,16 @@ EOF
         (interactive)
             summary "$SANDBOX_DIR" >&2
 
-	    if [ "$?" -eq 0 ]
-	    then
-		echo
-		read -p "Commit these changes? [y/N] " DO_COMMIT >&2
-		case "$DO_COMMIT" in
-                    (y|Y|yes|YES) commit "$SANDBOX_DIR";;
-                    (*) printf "Not commiting.\n" >&2
-			echo "$SANDBOX_DIR";;
-		esac
-	    fi
+        if [ "$?" -eq 0 ]
+        then
+            echo
+            read -p "Commit these changes? [y/N] " DO_COMMIT >&2
+            case "$DO_COMMIT" in
+                (y|Y|yes|YES) commit "$SANDBOX_DIR";;
+                (*) printf "Not commiting.\n" >&2
+                echo "$SANDBOX_DIR";;
+            esac
+        fi
         ;;
     esac
 }
@@ -101,13 +101,13 @@ summary() {
 
     if [ "$changed_files" ]
     then
-	echo
+        echo
         echo "Changes detected in the following files:"
         echo
         echo "$changed_files"
-	return 0
+    return 0
     else
-	return 1
+    return 1
     fi
 }
 
@@ -129,16 +129,17 @@ commit() {
         then # whiteout file
             rm "${changed_file#$SANDBOX_DIR/upperdir}"
         elif [ -f "$changed_file" ]
-	    then # normal file
+        then # normal file
             dest_path="${changed_file#$SANDBOX_DIR/upperdir}"
+            ## Create the directory if neede dbefore copying the file
             dirname=$(dirname "$dest_path")
             mkdir -p "$dirname"
             cp "$changed_file" "$dest_path"
         fi
-	
+    
         if [ $? -ne 0 ]
-	    then
-	    # TODO collect errors and summarize later
+        then
+        # TODO collect errors and summarize later
             printf "couldn't commit $changed_file\n"
             exit 1
         fi


### PR DESCRIPTION
This resolves #13, which was suffering from two issues.

### dev mount

The `/dev` directory is a mount (and not an actual directory) and therefore needs to be remounted instead of overlayfs'ed. For now, I just created a new bind mount of /dev inside the container root, but maybe we want to limit which files we want to bind in /dev (e.g., `/dev/null` but not other devices with side-effects). 

### Missed directory

When running `git clone ...` and after asking to commit the changes, the top level directory was not created and therefore we got an error. I fixed this by doing `mkdir -p` before `cp` but I think that in a later PR we have to replace commit and summary with programs in a different PL so that we can have more fine-grained control.
