### PR TITLE
Fix DNS when resolv.conf is linked

### DIFF
--- a/try
+++ b/try
@@ -25,6 +25,7 @@ try() {
 
     mount_and_execute=$(mktemp)
     chroot_executable=$(mktemp)
+    resolvconf=$(cat /etc/resolv.conf)
     cat >"$mount_and_execute" <<EOF
 #!/bin/sh
 
@@ -43,6 +44,8 @@ EOF
     cat >"$chroot_executable" <<EOF
 #!/bin/sh
                               
+rm /etc/resolv.conf &&
+echo "$resolvconf" > /etc/resolv.conf &&
 mount -t proc proc /proc &&   
 cd $START_DIR && 
 exec $@

--- a/try
+++ b/try
@@ -123,7 +123,7 @@ commit() {
     # This is different from the one in summary because it also includes all directories.
     # TODO: Could be made more efficient by only appending directories to the already computed
     #       changed_files from summary.
-    changed_files=$(find "$SANDBOX_DIR/upperdir/" -type f -o \( -type c -size 0 \) -o -type d | grep -v -e .rkr -e Rikerfile)
+    changed_files=$(find "$SANDBOX_DIR/upperdir/" -type f -o \( -type c -size 0 \) -o -type d | grep -v -e .rkr -e Rikerfile -e resolv.conf)
 
     while IFS= read -r changed_file; do
         local_file="${changed_file#$SANDBOX_DIR/upperdir}"

--- a/try
+++ b/try
@@ -101,7 +101,7 @@ summary() {
     
     # TODO let people control what's ignored
     # We don't include directories here since that would be too verbose for the summary.
-    changed_files=$(find "$SANDBOX_DIR/upperdir/" -type f -or \( -type c -size 0 \) | grep -v -e .rkr -e Rikerfile)
+    changed_files=$(find "$SANDBOX_DIR/upperdir/" -type f -or \( -type c -size 0 \) | grep -v -e .rkr -e Rikerfile -e resolv.conf)
 
     if [ "$changed_files" ]
     then


### PR DESCRIPTION
In certain systems where resolv.conf is linked, the link will break and dns will fail.
Here we first read resolv.conf, then we write it in the overlayfs resolv.conf.

closes #12 