### PR TITLE
Support GID mapping

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,6 @@ jobs:
       #         body: body,
       #       })     
       - name: Exit Code
-        working-directory: /home/runner/try/test
         run: |
           # check if everything executed without errors
           bash exit_code.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,9 +25,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Running Correctness Tests
         run: |
-          cd ..
-          cp -r try ~
-          cd ~/try
           uname -a
           sudo apt-get update
           sudo apt-get install strace

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,4 +58,4 @@ jobs:
       - name: Exit Code
         run: |
           # check if everything executed without errors
-          bash exit_code.sh
+          bash test/exit_code.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
           uname -a
           sudo apt-get update
           sudo apt-get install strace
+          bash ./test.sh
           bash ./test/run_tests.sh  
           # get the timer
           timer=$(LANG=en_us_88591; date)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
           uname -a
           sudo apt-get update
           sudo apt-get install strace
-          bash ./test.sh
+          bash ./setup.sh
           bash ./test/run_tests.sh  
           # get the timer
           timer=$(LANG=en_us_88591; date)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+gidmapper

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ We're setting out to change that.
 
 ### Dependencies
 
+Requires `netcat-openbsd` and `procps`.
+
 Has been tested on the following distributions:
 * `Ubuntu 20.04 LTS` or later
 * `Debian 12`
@@ -31,6 +33,8 @@ You only need the [`try` script](https://raw.githubusercontent.com/binpash/try/m
 ```ShellSession
 $ git clone https://github.com/binpash/try.git
 ```
+
+You would also want to install the `gidmapper`, simply run `sh setup.sh`.
 
 ## Example Usage
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,2 +1,3 @@
 wget https://github.com/ericzty/gidmapper/releases/download/0.0.3/gidmapper
+chmod +x gidmapper
 sudo setcap 'CAP_SETGID=ep' gidmapper

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,2 @@
+wget https://github.com/ericzty/gidmapper/releases/download/0.0.3/gidmapper
+sudo setcap 'CAP_SETGID=ep' gidmapper

--- a/try
+++ b/try
@@ -213,8 +213,17 @@ mapper() {
     nc -Ul "$socket1" > /dev/null
     # Get the pid of the unshare process with current pid as parent
     pid=$(pgrep -P $$ -f unshare)
+
     # Map root user to current user, and all groups
-    ./gidmapper $pid 0 $(id -u) 1 0 0 65535
+    if [ "$(id -u)" = 0 ]
+    then
+        # If we're running as root, we can map all the users
+        ./gidmapper $pid 0 0 65535 0 0 65535
+    else
+        # If not running as root, we can only mount the caller user
+        ./gidmapper $pid 0 $(id -u) 1 0 0 65535
+    fi
+
     # Notify the unshare process that we have finished
     # -U: use unix domain socket
     # -q0: don't wait after EOF

--- a/try
+++ b/try
@@ -8,17 +8,6 @@ set -x
 # 2 -- input error
 
 ################################################################################
-# Change uid/gid mapping
-################################################################################
-
-mapper() {
-    nc -l localhost 8887 > /dev/null
-    pid=$(ps | grep unshare | awk '{print $1;}')
-    ./gidmapper $pid 0 $(id -u) 1 0 0 65535
-    echo a | nc localhost -q0 8888
-}
-
-################################################################################
 # Run a command in an overlay
 ################################################################################
 
@@ -46,10 +35,10 @@ try() {
 #!/bin/sh
 
 # start gid mapping
-echo a | nc localhost -q0 8887
+echo a | nc localhost -q0 "$port1"
 
 # Wait for gid to be mapped
-nc -l localhost 8888 > /dev/null
+nc -l localhost "$port2" > /dev/null
 
 
 # actually mount the overlays
@@ -90,6 +79,10 @@ EOF
     # --pid: create a new process namespace (needed fr procfs to work right)
     # --fork: necessary if we do --pid
     #         "Creation of a persistent PID namespace will fail if the --fork option is not also specified."
+
+    freeports="$(shuf -n 2 -i 49152-65535)"
+    export port1="$(echo $freeports | tr ' ' '\n' | head -1)"
+    export port2="$(echo $freeports | tr ' ' '\n' | tail -1)"
 
     mapper&
     unshare --mount --user --pid --fork "$mount_and_execute"
@@ -199,13 +192,23 @@ $changed_files
 EOF
 }
 
+################################################################################
+# Change uid/gid mapping
+################################################################################
+
+mapper() {
+    nc -l localhost "$port1" > /dev/null
+    pid=$(ps | grep unshare | awk '{print $1;}')
+    ./gidmapper $pid 0 $(id -u) 1 0 0 65535
+    echo a | nc localhost -q0 "$port2"
+}
+
 
 ## Defines which changes we want to ignore in the summary and commit
 ## TODO: Make this be parametrizable, through a file for example
 ignore_changes() {
     grep -v -e .rkr -e Rikerfile
 }
-
 
 ################################################################################
 # Argument parsing

--- a/try
+++ b/try
@@ -1,10 +1,22 @@
 #!/bin/sh
+set -x
 
 # exit status invariants
 #
 # 0 -- command ran
 # 1 -- consistency error/failure
 # 2 -- input error
+
+################################################################################
+# Change uid/gid mapping
+################################################################################
+
+mapper() {
+    nc -l localhost 8887 > /dev/null
+    pid=$(ps | grep unshare | awk '{print $1;}')
+    ./gidmapper $pid 0 $(id -u) 1 0 $(id -g) 65535
+    echo a | nc localhost -q0 8888
+}
 
 ################################################################################
 # Run a command in an overlay
@@ -32,6 +44,13 @@ try() {
     export chroot_executable=$(mktemp)
     cat >"$mount_and_execute" <<"EOF"
 #!/bin/sh
+
+# start gid mapping
+echo a | nc localhost -q0 8887
+
+# Wait for gid to be mapped
+nc -l localhost 8888 > /dev/null
+
 
 # actually mount the overlays
 for top_dir in $(ls /)
@@ -71,7 +90,9 @@ EOF
     # --pid: create a new process namespace (needed fr procfs to work right)
     # --fork: necessary if we do --pid
     #         "Creation of a persistent PID namespace will fail if the --fork option is not also specified."
-    unshare --mount --map-root-user --user --pid --fork "$mount_and_execute"
+
+    mapper&
+    unshare --mount --user --pid --fork "$mount_and_execute"
 
     ################################################################################
     # commit?

--- a/try
+++ b/try
@@ -14,7 +14,7 @@ set -x
 mapper() {
     nc -l localhost 8887 > /dev/null
     pid=$(ps | grep unshare | awk '{print $1;}')
-    ./gidmapper $pid 0 $(id -u) 1 0 $(id -g) 65535
+    ./gidmapper $pid 0 $(id -u) 1 0 0 65535
     echo a | nc localhost -q0 8888
 }
 

--- a/try
+++ b/try
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -x
 
 # exit status invariants
 #

--- a/try
+++ b/try
@@ -34,9 +34,13 @@ try() {
 #!/bin/sh
 
 # start gid mapping
+# -U: use unix domain socket
+# -q0: don't wait after EOF on stdin
 echo a | nc -Uq0 "$socket1"
 
 # Wait for gid to be mapped
+# -l: listen
+# -U: use unix socket
 nc -lU "$socket2" > /dev/null
 
 
@@ -196,12 +200,16 @@ EOF
 
 mapper() {
     # Wait for unshare process to start
+    # -U: use unix domain socket
+    # -l: listen
     nc -Ul "$socket1" > /dev/null
     # Get the pid of the unshare process with current pid as parent
     pid=$(pgrep -P $$ -f unshare)
     # Map root user to current user, and all groups
     ./gidmapper $pid 0 $(id -u) 1 0 0 65535
     # Notify the unshare process that we have finished
+    # -U: use unix domain socket
+    # -q0: don't wait after EOF
     echo a | nc -Uq0 "$socket2"
 }
 

--- a/try
+++ b/try
@@ -195,9 +195,13 @@ EOF
 ################################################################################
 
 mapper() {
+    # Wait for unshare process to start
     nc -Ul "$socket1" > /dev/null
-    pid=$(ps | grep unshare | awk '{print $1;}')
+    # Get the pid of the unshare process with current pid as parent
+    pid=$(pgrep -P $$ -f unshare)
+    # Map root user to current user, and all groups
     ./gidmapper $pid 0 $(id -u) 1 0 0 65535
+    # Notify the unshare process that we have finished
     echo a | nc -Uq0 "$socket2"
 }
 

--- a/try
+++ b/try
@@ -34,10 +34,10 @@ try() {
 #!/bin/sh
 
 # start gid mapping
-echo a | nc localhost -q0 "$port1"
+echo a | nc -Uq0 "$socket1"
 
 # Wait for gid to be mapped
-nc -l localhost "$port2" > /dev/null
+nc -lU "$socket2" > /dev/null
 
 
 # actually mount the overlays
@@ -79,9 +79,8 @@ EOF
     # --fork: necessary if we do --pid
     #         "Creation of a persistent PID namespace will fail if the --fork option is not also specified."
 
-    freeports="$(shuf -n 2 -i 49152-65535)"
-    export port1="$(echo $freeports | tr ' ' '\n' | head -1)"
-    export port2="$(echo $freeports | tr ' ' '\n' | tail -1)"
+    export socket1="$(mktemp -u)"
+    export socket2="$(mktemp -u)"
 
     mapper&
     unshare --mount --user --pid --fork "$mount_and_execute"
@@ -196,10 +195,10 @@ EOF
 ################################################################################
 
 mapper() {
-    nc -l localhost "$port1" > /dev/null
+    nc -Ul "$socket1" > /dev/null
     pid=$(ps | grep unshare | awk '{print $1;}')
     ./gidmapper $pid 0 $(id -u) 1 0 0 65535
-    echo a | nc localhost -q0 "$port2"
+    echo a | nc -Uq0 "$socket2"
 }
 
 

--- a/try
+++ b/try
@@ -88,6 +88,7 @@ EOF
 
     mapper&
     unshare --mount --user --pid --fork "$mount_and_execute"
+    wait
 
     ################################################################################
     # commit?


### PR DESCRIPTION
For Context: Inside try, if we attempt to modify any file that is owned by (or is in a directory that is owned by) a group that is not the user id, overlayfs's copy_up will fail with EOVERFLOW because that GID is not mapped. We want to map the GIDs.

Supports gid mapping via https://github.com/ericzty/gidmapper
* Removed --map-root-user since we will be mapping them ourselves
* Spins off a background function (mapper) that waits for the unshare process to start by listening on a tcp socket
* The unshare process notifies the mapper function that it has started with a tcp call, then waits on another tcp socket for mapper to finish
* The mapper function finishes mapping the uid and gid, then notifies the unshare process via the tcp call for it to start mounting
* Removed the hack in CI that prompted this
* The TCP Port is selected at random with `shuf` from coreutils