### PR TITLE
Fix logs for mount

### DIFF
--- a/try
+++ b/try
@@ -30,6 +30,7 @@ try() {
 
     mount_and_execute=$(mktemp)
     export chroot_executable=$(mktemp)
+    export try_mount_log=$(mktemp)
     cat >"$mount_and_execute" <<"EOF"
 #!/bin/sh
 
@@ -40,7 +41,7 @@ do
     ## If the directory is not a mountpoint
     if [ -d "$top_dir_abs" ] && ! mountpoint -q "$top_dir_abs"; then
         ## TODO: The 
-        mount -t overlay overlay -o lowerdir=/"$top_dir",upperdir="$SANDBOX_DIR"/upperdir/"$top_dir",workdir="$SANDBOX_DIR"/workdir/"$top_dir" "$SANDBOX_DIR"/temproot/"$top_dir" 2> /tmp/try.log || echo "Warning: Failed mounting $top_dir_abs as an overlay..." 1>&2
+        mount -t overlay overlay -o lowerdir=/"$top_dir",upperdir="$SANDBOX_DIR"/upperdir/"$top_dir",workdir="$SANDBOX_DIR"/workdir/"$top_dir" "$SANDBOX_DIR"/temproot/"$top_dir" 2>> "$try_mount_log" || echo "Warning: Failed mounting $top_dir_abs as an overlay, see "$try_mount_log"" 1>&2
     fi
 done
 


### PR DESCRIPTION
* Use append instead of replace when writing to the log file.
* Use mktemp for log file instead of using a hardcoded file.