### PR TITLE
check if chroot_executable exists in target overlayfs, copy if not

### DIFF
--- a/try
+++ b/try
@@ -53,6 +53,9 @@ mount --rbind /dev "$SANDBOX_DIR/temproot/dev"
 ##               seemingly not impactful warning.
 mount --rbind --read-only /run "$SANDBOX_DIR/temproot/run" 2> /dev/null
 
+## Check if chroot_executable exists, #29
+cat "$SANDBOX_DIR/temproot/$chroot_executable" > /dev/null || cp $chroot_executable "$SANDBOX_DIR/temproot/$chroot_executable"
+
 unshare --root="$SANDBOX_DIR/temproot" /bin/bash "$chroot_executable"
 EOF
 

--- a/try
+++ b/try
@@ -54,7 +54,10 @@ mount --rbind /dev "$SANDBOX_DIR/temproot/dev"
 mount --rbind --read-only /run "$SANDBOX_DIR/temproot/run" 2> /dev/null
 
 ## Check if chroot_executable exists, #29
-cat "$SANDBOX_DIR/temproot/$chroot_executable" > /dev/null || cp $chroot_executable "$SANDBOX_DIR/temproot/$chroot_executable"
+if ! [ -f "$SANDBOX_DIR/temproot/$chroot_executable" ]; then
+    cp $chroot_executable "$SANDBOX_DIR/temproot/$chroot_executable"
+fi
+
 
 unshare --root="$SANDBOX_DIR/temproot" /bin/bash "$chroot_executable"
 EOF


### PR DESCRIPTION
If chroot executable does not exist due to /tmp is tmpfs, we want to copy it over so it can be run.

closes #29 