### PR TITLE
Fix nc race

### DIFF
--- a/try
+++ b/try
@@ -37,6 +37,7 @@ try() {
 # start gid mapping
 # -U: use unix domain socket
 # -q0: don't wait after EOF on stdin
+# Sometimes this will run first before the other nc starts listening, so we will retry
 while ! echo a | nc -Uq0 "$socket1" 2> /dev/null; do sleep 0.25 ; done
 
 # Wait for gid to be mapped

--- a/try
+++ b/try
@@ -37,7 +37,7 @@ try() {
 # start gid mapping
 # -U: use unix domain socket
 # -q0: don't wait after EOF on stdin
-echo a | nc -Uq0 "$socket1"
+while ! echo a | nc -Uq0 "$socket1" 2> /dev/null; do sleep 0.25 ; done
 
 # Wait for gid to be mapped
 # -l: listen


### PR DESCRIPTION
Sometimes the nc sender will start before the nc listener starts, so we’re adding a while loop with `sleep 0.25` (most optimal on my machine, if sleep 0 it will actually retry more and takes more time).

This looks like a hack, is there a better solution?
This is also why github actions sometimes hung. 