### PR TITLE
[WIP] Enable job control

### DIFF
--- a/try
+++ b/try
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -m
 
 # exit status invariants
 #


### PR DESCRIPTION
allow interactive commands to not send summary to background by setting `set -m`

- [ ] Fix #5
- [ ] try explore shortcut?
- [ ] docs