### PR TITLE
Run script using source and not exec

### DIFF
--- a/test/misc/touch_echo_and_rm.sh
+++ b/test/misc/touch_echo_and_rm.sh
@@ -1,3 +1,0 @@
-touch $1
-echo "test" > $2
-rm $3

--- a/try
+++ b/try
@@ -39,6 +39,7 @@ try() {
     mount_and_execute=$(mktemp)
     export chroot_executable=$(mktemp)
     export try_mount_log=$(mktemp)
+    export script_to_execute=$(mktemp)
     cat >"$mount_and_execute" <<"EOF"
 #!/bin/sh
 
@@ -86,8 +87,10 @@ EOF
                               
 mount -t proc proc /proc &&   
 cd $START_DIR && 
-exec $@
+source "$script_to_execute"
 EOF
+
+    echo "$@" >"$script_to_execute"
 
     chmod +x "$mount_and_execute" "$chroot_executable"
 


### PR DESCRIPTION
Cleans up the testing infrastructure and modifies try to run the input script using source instead of `exec` (to be able to run sequences of commands).