### PR TITLE
Make the whiteout file check more precise

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -155,6 +155,26 @@ EOF
     diff -q expected.out out.txt
 }
 
+test_summary()
+{
+    local try_workspace=$1
+    cp $RESOURCE_DIR/file.txt.gz "$try_workspace/"
+    cd "$try_workspace/"
+
+    ## Set up expected output
+    touch expected1.txt
+    echo 'test' >expected2.txt
+
+    try_example_dir=$(mktemp -d)
+    "$try" -D $try_example_dir "touch file_1.txt; echo test > file_2.txt; rm file.txt.gz"
+    "$try" summary $try_example_dir > summary.out
+
+    ## Check that the summary correctly identifies every change
+    grep -x "$PWD/file_1.txt (modified/added)" <summary.out &&
+        grep -x "$PWD/file_2.txt (modified/added)" <summary.out &&
+        grep -x "$PWD/file.txt.gz (deleted)" <summary.out
+}
+
 # a test that deliberately fails (for testing CI changes)
 test_fail()
 {
@@ -174,6 +194,7 @@ if [ "$#" -eq 0 ]; then
     run_test test_touch_and_rm_D_flag_commit
     run_test test_pipeline
     run_test test_cmd_sbst_and_var
+    run_test test_summary
 
 # uncomment this to force a failure
 #    run_test test_fail

--- a/try
+++ b/try
@@ -214,7 +214,7 @@ EOF
 ## Checks if a file is an overlayfs whiteout file
 is_whiteout_file()
 {
-    local file="$1"
+    file="$1"
     [ -c "$file" ] && ! [ -s "$file" ] && [ "$(stat -c %t,%T "$file")" = "0,0" ]
 }
 

--- a/try
+++ b/try
@@ -157,7 +157,7 @@ summary() {
         then # new directory
             ## KK 2023-06-20 This is not reachable since the `type -d` option is not given to find above.
             echo "$local_file (created)"
-        elif [ -c "$changed_file" ] && ! [ -s "$changed_file" ]
+        elif is_whiteout_file "$changed_file"
         then # whiteout file
             echo "$local_file (deleted)"
         elif [ -f "$changed_file" ]
@@ -185,7 +185,7 @@ commit() {
         if [ -d "$changed_file" ] && ! [ -d "${local_file}" ]
         then # new directory
             mkdir "${local_file}"
-        elif [ -c "$changed_file" ] && ! [ -s "$changed_file" ]
+        elif is_whiteout_file "$changed_file"
         then # whiteout file
             rm "${local_file}"
         elif [ -f "$changed_file" ]
@@ -205,6 +205,12 @@ $changed_files
 EOF
 }
 
+## Checks if a file is an overlayfs whiteout file
+is_whiteout_file()
+{
+    local file="$1"
+    [ -c "$file" ] && ! [ -s "$file" ] && [ "$(stat -c %t,%T "$file")" = "0,0" ]
+}
 
 ## Defines which changes we want to ignore in the summary and commit
 ## TODO: Make this be parametrizable, through a file for example


### PR DESCRIPTION
Addresses #42

I tried to create a test for this that differentiates between a real character device file being created and the whiteout file but I found it really hard (creating an actual device file requires sudo and using fakeroot does not create an actual character device file). 

Any ideas on how to create a test would be pretty useful :)