### PR TITLE
Add Shellcheck to CI job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,10 @@ jobs:
       - uses: actions/checkout@v2 
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install and run ShellCheck
+        run: |
+          sudo apt-get install -y shellcheck
+          shellcheck ./try
       - name: Running Correctness Tests
         run: |
           cd ..

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,8 @@ jobs:
       - name: Install and run ShellCheck
         run: |
           sudo apt-get install -y shellcheck
-          shellcheck ./try
+          # run shellcheck and return 1 only if warnings are found. 
+          shellcheck -S warning ./try
       - name: Running Correctness Tests
         run: |
           cd ..


### PR DESCRIPTION
Resolves #72 and adds shellcheck to the CI job. Fails the CI job on warnings or errors (-S warning), not informational messages. You may want to bump the -S to error instead.