### PR TITLE
Reuse sandbox and add tests

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -160,7 +160,10 @@ test_reuse_problematic_sandbox()
     try_example_dir=$(mktemp -d)
     "$try" -D $try_example_dir "touch file_1.txt; echo test > file_2.txt; rm file.txt.gz"
 
-    ## This test should do something that is actually problematic
+    ## KK 2023-06-29 This test is meant to modify the sandbox directory in an illegal way,
+    ##               at the moment, this modification will be caught as illegal by `try`,
+    ##               but it doesn't seem to both overlayfs at all.
+    ## TODO: Extend this with more problematic overlayfs modifications.
     touch "$try_example_dir/temproot/bin/foo"
     ! "$try" -D $try_example_dir "rm file_1.txt; echo test2 >> file_2.txt; touch file.txt.gz"
 }

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -125,6 +125,59 @@ test_touch_and_rm_D_flag_commit()
         [ ! -f file.txt.gz ]
 }
 
+test_reuse_sandbox()
+{
+    local try_workspace=$1
+    cp $RESOURCE_DIR/file.txt.gz "$try_workspace/"
+    cd "$try_workspace/"
+    
+    ## Set up expected output
+    echo 'test' >expected2.txt 
+    echo 'test2' >>expected2.txt 
+    touch expected3.out
+
+    try_example_dir=$(mktemp -d)
+    "$try" -D $try_example_dir "touch file_1.txt; echo test > file_2.txt; rm file.txt.gz"
+    "$try" -D $try_example_dir "rm file_1.txt; echo test2 >> file_2.txt; touch file.txt.gz"
+    $try commit $try_example_dir
+    
+    [ ! -f file_1.txt ] &&
+        diff -q expected2.txt file_2.txt &&
+        diff -q expected3.out file.txt.gz
+}
+
+test_reuse_problematic_sandbox()
+{
+    local try_workspace=$1
+    cp $RESOURCE_DIR/file.txt.gz "$try_workspace/"
+    cd "$try_workspace/"
+    
+    ## Set up expected output
+    echo 'test' >expected2.txt 
+    echo 'test2' >>expected2.txt 
+    touch expected3.out
+
+    try_example_dir=$(mktemp -d)
+    "$try" -D $try_example_dir "touch file_1.txt; echo test > file_2.txt; rm file.txt.gz"
+
+    ## This test should do something that is actually problematic
+    touch "$try_example_dir/temproot/bin/foo"
+    ! "$try" -D $try_example_dir "rm file_1.txt; echo test2 >> file_2.txt; touch file.txt.gz"
+}
+
+test_non_existent_sandbox()
+{
+    local try_workspace=$1
+    cp $RESOURCE_DIR/file.txt.gz "$try_workspace/"
+    cd "$try_workspace/"
+    
+    try_example_dir="non-existent"
+    ! "$try" -D $try_example_dir "touch file_1.txt" 2>/dev/null &&
+    ! "$try" summary $try_example_dir 2>/dev/null &&
+    ! "$try" commit $try_example_dir 2>/dev/null &&
+    ! "$try" explore $try_example_dir 2>/dev/null 
+}
+
 test_pipeline()
 {
     local try_workspace=$1
@@ -225,6 +278,9 @@ if [ "$#" -eq 0 ]; then
     run_test test_untar_D_flag_commit
     run_test test_touch_and_rm_no_flag
     run_test test_touch_and_rm_D_flag_commit
+    run_test test_reuse_sandbox
+    run_test test_reuse_problematic_sandbox
+    run_test test_non_existent_sandbox
     run_test test_pipeline
     run_test test_cmd_sbst_and_var
     run_test test_summary

--- a/try
+++ b/try
@@ -22,7 +22,24 @@ TRY_VERSION="0.1.0"
 try() {
     START_DIR="$PWD"
 
-    [ "$SANDBOX_DIR" ] || SANDBOX_DIR=$(mktemp -d)
+    if [ "$SANDBOX_DIR" ]
+    then
+        ## If the name of a sandbox is given then we need to exit prematurely if its directory doesn't exist
+        [ ! -d "$SANDBOX_DIR" ] && { printf "%s: could not find directory $SANDBOX_DIR\n" "$(basename $0)" >&2; exit 2; } 
+    else
+        ## Create a new sandbox if one was not given
+        SANDBOX_DIR=$(mktemp -d)
+    fi
+
+    ## If the sandbox is not valid we exit early
+    if ! sandbox_valid_or_empty "$SANDBOX_DIR"
+    then
+        printf "%s: given sandbox $SANDBOX_DIR is invalid\n" "$(basename $0)" >&2
+        exit 1 
+    fi
+
+    ## Make any directories that don't already exist, this is OK to do here
+    ##  because we have already checked if it valid.
     export SANDBOX_DIR
     mkdir -p "$SANDBOX_DIR/upperdir" "$SANDBOX_DIR/workdir" "$SANDBOX_DIR/temproot"
 
@@ -32,7 +49,7 @@ try() {
     do
         ## Only make the directory if the original is a directory too
         if [ -d "$top_dir" ]; then
-            mkdir "$SANDBOX_DIR"/upperdir/"$top_dir" "$SANDBOX_DIR"/workdir"/$top_dir" "$SANDBOX_DIR"/temproot/"$top_dir"
+            mkdir -p "$SANDBOX_DIR"/upperdir/"$top_dir" "$SANDBOX_DIR"/workdir"/$top_dir" "$SANDBOX_DIR"/temproot/"$top_dir"
         fi
     done
 
@@ -140,7 +157,7 @@ summary() {
         exit 2
     elif ! [ -d "$SANDBOX_DIR/upperdir" ]
     then
-        printf "%s: could not find directory $SANDBOX_DIR\n" "$(basename $0)" >&2
+        printf "%s: could not find directory $SANDBOX_DIR/upperdir\n" "$(basename $0)" >&2
         exit 1
     fi
     
@@ -178,6 +195,16 @@ EOF
 ################################################################################
 
 commit() {
+    if ! [ -d "$SANDBOX_DIR" ]
+    then
+        printf "%s: could not find directory $SANDBOX_DIR\n" "$(basename $0)" >&2
+        exit 2
+    elif ! [ -d "$SANDBOX_DIR/upperdir" ]
+    then
+        printf "%s: could not find directory $SANDBOX_DIR/upperdir\n" "$(basename $0)" >&2
+        exit 1
+    fi
+
     changed_files=$(find_upperdir_changes "$SANDBOX_DIR")
     summary_output=$(process_changes "$SANDBOX_DIR" "$changed_files")
 
@@ -262,6 +289,31 @@ process_changes() {
 $changed_files
 EOF
 }
+
+## Returns 0 if a sandbox is empty (fresh for use)
+## or if it already exists, and is well-formed 
+sandbox_valid_or_empty() {
+    sandbox_dir="$1"
+    if [ ! -d "$sandbox_dir/upperdir" ] && [ ! -d "$sandbox_dir/workdir" ] && [ ! -d "$sandbox_dir/temproot" ]
+    then
+        ## No sandbox directory exists so we can happily return
+        return 0
+    fi
+
+    ## The sandbox already exists so we now need to check if it is valid
+    ## Validity requirements:
+    ## - no file exists in the temproot tree, i.e., all directories are empty
+    ##
+    ## TODO: Make this validity assertion tighter
+    ## KK 2023-06-28 workdir seems to be non-empty after a single use, is that expected?
+    if [ ! -z "$(find "$sandbox_dir/temproot" -depth -not -type d)" ]
+    then
+        return 1
+    fi
+
+    return 0
+}
+
 
 
 ################################################################################


### PR DESCRIPTION
This PR adds tests and fixes to address #41. Currently, the sandbox_valid check is not adequately extensive and we need to make it stricter.

In particular, one check that feels relevant is to determine whether the directory is already used by another overlay (which is supposedly not allowed based on the overlayfs documentation). This actually comes up in practice (I paste a manual test below) but I can't figure out how to determine it ahead of time (e.g., the workdir contains a work directory if the overlayfs is mounted or not).

Erroneous test where overlay is in use:
```
## In one terminal start an overlay and leave it running
kallas@node0:~/try$ ./try -D ../foo bash
Warning: Failed mounting /proj as an overlay, see /tmp/tmp.2qrQ08c0Un
Warning: Failed mounting /sys/kernel/tracing as an overlay, see /tmp/tmp.2qrQ08c0Un
Warning: Failed mounting /proj/pash-PG0 as an overlay, see /tmp/tmp.2qrQ08c0Un
root@node0:~/try# 

## In another terminal
kallas@node0:~/try$ ./try -D ../foo echo "README" > README
Warning: Failed mounting /proj as an overlay, see /tmp/tmp.2qrQ08c0Un
Warning: Failed mounting /sys/kernel/tracing as an overlay, see /tmp/tmp.2qrQ08c0Un
Warning: Failed mounting /proj/pash-PG0 as an overlay, see /tmp/tmp.2qrQ08c0Un
kallas@node0:~/try$ 

## The error: no summary shown or commit prompt.


```