### PR TITLE
Implement Multi-Lower-Layer Overlay Support through Merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,15 +158,12 @@ explore /tmp/tmp.X6OQb5tJwr` to explore an existing sandbox.
 To specify multiple lower directories for overlay (by merging them together), you can use the `-L` flag followed by a colon-separated list of directories. The directories on the left have higher precedence and can overwrite the directories on the right:
 
 ```ShellSession
-$ try -D sandbox1 "echo 'File 1 Contents - sandbox1' > file1.txt"
-...
-$ try -D sandbox2 "echo 'File 2 Contents - sandbox2' > file2.txt"
-...
-$ try -D sandbox3 "echo 'File 2 Contents - sandbox3' > file2.txt"
-...
+$ try -D /tmp/sandbox1 "echo 'File 1 Contents - sandbox1' > file1.txt"
+$ try -D /tmp/sandbox2 "echo 'File 2 Contents - sandbox2' > file2.txt"
+$ try -D /tmp/sandbox3 "echo 'File 2 Contents - sandbox3' > file2.txt"
 
 # Now use the -L flag to merge both sandbox directories together, with sandbox3 having precedence over sandbox2
-$ try -L "sandbox3:sandbox2:sandbox1" "cat file1.txt file2.txt"
+$ try -L "/tmp/sandbox3:/tmp/sandbox2:/tmp/sandbox1" "cat file1.txt file2.txt"
 File 1 Contents - sandbox1
 File 2 Contents - sandbox3
 ```

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ $ try commit rustup-sandbox
 You can also run `try explore` to open your current shell in try, or `/try
 explore /tmp/tmp.X6OQb5tJwr` to explore an existing sandbox.
 
-To specify multiple lower directories for overlay (by merging them together), you can use the `-L` flag followed by a colon-separated list of directories. The directories on the left have higher precedence and can overwrite the directories on the right:
+To specify multiple lower directories for overlay (by merging them together), you can use the `-L` (implies `-n`) flag followed by a colon-separated list of directories. The directories on the left have higher precedence and can overwrite the directories on the right:
 
 ```ShellSession
 $ try -D /tmp/sandbox1 "echo 'File 1 Contents - sandbox1' > file1.txt"

--- a/README.md
+++ b/README.md
@@ -155,6 +155,27 @@ $ try commit rustup-sandbox
 You can also run `try explore` to open your current shell in try, or `/try
 explore /tmp/tmp.X6OQb5tJwr` to explore an existing sandbox.
 
+To specify multiple lower directories for overlay (by merging them together), you can use the `-L` flag followed by a colon-separated list of directories. The directories on the left have higher precedence and can overwrite the directories on the right:
+
+```ShellSession
+$ try -D rustup-sandbox "curl https://sh.rustup.rs > rustup.sh"
+...
+$ try -L rustup-sandbox "sh rustup.sh"
+
+Changes detected in the following files:
+
+rustup-sandbox//upperdir/home/ubuntu/.profile (modified/added)
+rustup-sandbox//upperdir/home/ubuntu/.bashrc (modified/added)
+rustup-sandbox//upperdir/home/ubuntu/.rustup/update-hashes/stable-x86_64-unknown-linux-gnu (modified/added)
+...
+
+Commit these changes? [y/N] y
+
+```
+
+In this example, `try`` will merge `/lowerdir1`, `/lowerdir2` and `/lowerdir3` together before mounting the overlay. This way, you can combine the contents of multiple `try` sandboxes .
+
+
 ## Known Issues
 Any command that interacts with other users/groups will fail since only the
 current user's UID/GID are mapped. However, the [future

--- a/README.md
+++ b/README.md
@@ -158,22 +158,20 @@ explore /tmp/tmp.X6OQb5tJwr` to explore an existing sandbox.
 To specify multiple lower directories for overlay (by merging them together), you can use the `-L` flag followed by a colon-separated list of directories. The directories on the left have higher precedence and can overwrite the directories on the right:
 
 ```ShellSession
-$ try -D rustup-sandbox "curl https://sh.rustup.rs > rustup.sh"
+$ try -D sandbox1 "echo 'File 1 Contents - sandbox1' > file1.txt"
 ...
-$ try -L rustup-sandbox "sh rustup.sh"
-
-Changes detected in the following files:
-
-rustup-sandbox//upperdir/home/ubuntu/.profile (modified/added)
-rustup-sandbox//upperdir/home/ubuntu/.bashrc (modified/added)
-rustup-sandbox//upperdir/home/ubuntu/.rustup/update-hashes/stable-x86_64-unknown-linux-gnu (modified/added)
+$ try -D sandbox2 "echo 'File 2 Contents - sandbox2' > file2.txt"
+...
+$ try -D sandbox3 "echo 'File 2 Contents - sandbox3' > file2.txt"
 ...
 
-Commit these changes? [y/N] y
-
+# Now use the -L flag to merge both sandbox directories together, with sandbox3 having precedence over sandbox2
+$ try -L "sandbox3:sandbox2:sandbox1" "cat file1.txt file2.txt"
+File 1 Contents - sandbox1
+File 2 Contents - sandbox3
 ```
 
-In this example, `try`` will merge `/lowerdir1`, `/lowerdir2` and `/lowerdir3` together before mounting the overlay. This way, you can combine the contents of multiple `try` sandboxes .
+In this example, `try` will merge `/sandbox1`, `/sandbox2` and `/sandbox3` together before mounting the overlay. This way, you can combine the contents of multiple `try` sandboxes.
 
 
 ## Known Issues

--- a/completions/try.bash
+++ b/completions/try.bash
@@ -17,13 +17,16 @@ _try() {
 
     case "${cmd}" in
         (try)
-            opts="-n -y -v -h -i -D -U summary commit explore"
+            opts="-n -y -v -h -i -D -U -L summary commit explore"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]]
             then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                (-L)
+                    COMPREPLY=($(compgen -d "${cur}"))
+                    return 0;;
                 (-D)
                     COMPREPLY=($(compgen -d "${cur}"))
                     return 0;;

--- a/docs/try.1.md
+++ b/docs/try.1.md
@@ -55,7 +55,7 @@ This option is recommended in case OverlayFS fails.
 
 -L *LOWER_DIRS*
 
-: Specify a colon-separated list of directories to be used as lower directories for the overlay, formatted as "dir1:dir2:...:dirn".
+: Specify a colon-separated list of directories to be used as lower directories for the overlay, formatted as "dir1:dir2:...:dirn" (implies -n).
 
 
 ## Subcommands

--- a/docs/try.1.md
+++ b/docs/try.1.md
@@ -6,7 +6,7 @@
 try - run a command in an overlay
 
 # SYNOPSIS
-| try [-ny] [-i PATTERN] [-D DIR] [-U PATH] CMD [ARG ...]
+| try [-ny] [-i PATTERN] [-D DIR] [-U PATH] [-L LOWER_DIRS] CMD [ARG ...]
 | try summary [DIR]
 | try commit [DIR]
 | try explore
@@ -52,6 +52,11 @@ While using *try* you can choose to commit the result to the filesystem or compl
 
 : Use the unionfs helper implementation defined in the *PATH* (e.g., mergerfs, unionfs-fuse) instead of the default.
 This option is recommended in case OverlayFS fails.
+
+-L *LOWER_DIRS*
+
+: Specify a colon-separated list of directories to be used as lower directories for the overlay, formatted as "dir1:dir2:...:dirn".
+
 
 ## Subcommands
 
@@ -122,6 +127,12 @@ Alternatively, you can specify your own overlay directory as follows (note that 
 
 ```
 try -D try_dir gunzip file.txt.gz
+```
+
+To use multiple lower directories for overlay (by merging them), you can use the `-L` flag followed by a colon-separated list of directories. The directories on the left have higher precedence and can overwrite the directories on the right:
+
+```
+try -L /lowerdir1:/lowerdir2:/lowerdir3 gunzip file.txt.gz
 ```
 
 You can inspect the changes made inside a given overlay directory:

--- a/test/merge_multiple_dirs.sh
+++ b/test/merge_multiple_dirs.sh
@@ -35,7 +35,6 @@ cleanup() {
     then
        rm "$expected2"
     fi
-    
     if [ -f "$expected3" ]
     then
        rm "$expected3"

--- a/test/merge_multiple_dirs.sh
+++ b/test/merge_multiple_dirs.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+TRY_TOP="${TRY_TOP:-$(git rev-parse --show-toplevel --show-superproject-working-tree)}"
+TRY="$TRY_TOP/try"
+
+cleanup() {
+    cd /
+
+    if [ -d "$try_workspace" ]
+    then
+        rm -rf "$try_workspace" >/dev/null 2>&1
+    fi
+
+    if [ -f "$try_example_dir1" ]
+    then
+        rm "$try_example_dir1"
+    fi
+
+    if [ -f "$try_example_dir2" ]
+    then
+        rm "$try_example_dir2"
+    fi
+
+    if [ -f "$try_example_dir3" ]
+    then
+        rm "$try_example_dir3"
+    fi
+
+    if [ -f "$expected1" ]
+    then
+       rm "$expected1"
+    fi
+
+    if [ -f "$expected2" ]
+    then
+       rm "$expected2"
+    fi
+    
+    if [ -f "$expected3" ]
+    then
+       rm "$expected3"
+    fi
+
+    if [ -f "$expected4" ]
+    then
+       rm "$expected4"
+    fi
+}
+
+trap 'cleanup' EXIT
+
+try_workspace="$(mktemp -d -p .)"
+cp "$TRY_TOP/test/resources/file.txt.gz" "$try_workspace/"
+cd $try_workspace
+
+try_example_dir1="$(mktemp -d)"
+try_example_dir2="$(mktemp -d)"
+try_example_dir3="$(mktemp -d)"
+
+expected1="$(mktemp)"
+expected2="$(mktemp)"
+expected3="$(mktemp)"
+
+touch "$expected1"
+echo "test2" > $expected2
+echo "test3" > $expected3
+
+"$TRY" -D "$try_example_dir1" "touch file_1.txt; echo test > file_2.txt; rm file.txt.gz" || return 1
+"$TRY" -D "$try_example_dir2" "echo test2 > file_2.txt" || return 2
+"$TRY" -D "$try_example_dir3" "echo test3 > file_3.txt" || return 3
+"$TRY" -L "$try_example_dir3:$try_example_dir2:$try_example_dir1" -y "cat file_1.txt > out1; cat file_2.txt > out2; cat file_3.txt > out3"|| return 4
+
+diff -q "$expected1" out1 || return 5
+diff -q "$expected2" out2 || return 6
+diff -q "$expected3" out3 || return 7
+
+! [ -f out4 ] || return 8

--- a/test/merge_multiple_dirs.sh
+++ b/test/merge_multiple_dirs.sh
@@ -39,18 +39,13 @@ cleanup() {
     then
        rm "$expected3"
     fi
-
-    if [ -f "$expected4" ]
-    then
-       rm "$expected4"
-    fi
 }
 
 trap 'cleanup' EXIT
 
 try_workspace="$(mktemp -d -p .)"
 cp "$TRY_TOP/test/resources/file.txt.gz" "$try_workspace/"
-cd $try_workspace
+cd "$try_workspace" || return 1
 
 try_example_dir1="$(mktemp -d)"
 try_example_dir2="$(mktemp -d)"
@@ -61,16 +56,16 @@ expected2="$(mktemp)"
 expected3="$(mktemp)"
 
 touch "$expected1"
-echo "test2" > $expected2
-echo "test3" > $expected3
+echo "test2" > "$expected2"
+echo "test3" > "$expected3"
 
-"$TRY" -D "$try_example_dir1" "touch file_1.txt; echo test > file_2.txt; rm file.txt.gz" || return 1
-"$TRY" -D "$try_example_dir2" "echo test2 > file_2.txt" || return 2
-"$TRY" -D "$try_example_dir3" "echo test3 > file_3.txt" || return 3
-"$TRY" -L "$try_example_dir3:$try_example_dir2:$try_example_dir1" -y "cat file_1.txt > out1; cat file_2.txt > out2; cat file_3.txt > out3"|| return 4
+"$TRY" -D "$try_example_dir1" "touch file_1.txt; echo test > file_2.txt; rm file.txt.gz" || return 2
+"$TRY" -D "$try_example_dir2" "echo test2 > file_2.txt" || return 3
+"$TRY" -D "$try_example_dir3" "echo test3 > file_3.txt" || return 4
+"$TRY" -L "$try_example_dir3:$try_example_dir2:$try_example_dir1" -y "cat file_1.txt > out1; cat file_2.txt > out2; cat file_3.txt > out3"|| return 5
 
-diff -q "$expected1" out1 || return 5
-diff -q "$expected2" out2 || return 6
-diff -q "$expected3" out3 || return 7
+diff -q "$expected1" out1 || return 6
+diff -q "$expected2" out2 || return 7
+diff -q "$expected3" out3 || return 8
 
-! [ -f out4 ] || return 8
+! [ -f out4 ] || return 9

--- a/try
+++ b/try
@@ -56,7 +56,7 @@ try() {
     findmnt --real -r -o target -n >>"$DIRS_AND_MOUNTS"
     sort -u -o "$DIRS_AND_MOUNTS" "$DIRS_AND_MOUNTS"
 
-    # Calculate UPDATED_DIRS_AND_MOUNTS that contains the merge arguments in LOWER_DIRS 
+    # Calculate UPDATED_DIRS_AND_MOUNTS that contains the merge arguments in LOWER_DIRS
     UPDATED_DIRS_AND_MOUNTS="$(mktemp)"
     export UPDATED_DIRS_AND_MOUNTS
     while IFS="" read -r mountpoint
@@ -64,7 +64,7 @@ try() {
         new_mountpoint=""
         temp_file=$(mktemp)
         echo "$LOWER_DIRS" | tr ':' '\n' > "$temp_file" # Split LOWER_DIRS into lines
-        
+
         while IFS="" read -r lower_dir
         do
             temp_mountpoint="$lower_dir/upperdir$mountpoint"
@@ -520,7 +520,7 @@ Usage: $TRY_COMMAND [-nvhy] [-i PATTERN] [-D DIR] [-U PATH] [-L "dir1:dir2:..."]
 
   -v                 show version information (and exit)
   -h                 show this usage message (and exit)
-  
+
 Subcommands:
   $TRY_COMMAND summary DIR   show the summary for the overlay in DIR
   $TRY_COMMAND commit DIR    commit the overlay in DIR

--- a/try
+++ b/try
@@ -56,6 +56,33 @@ try() {
     findmnt --real -r -o target -n >>"$DIRS_AND_MOUNTS"
     sort -u -o "$DIRS_AND_MOUNTS" "$DIRS_AND_MOUNTS"
 
+    # Update DIRS_AND_MOUNTS based on LOWER_DIRS
+    UPDATED_DIRS_AND_MOUNTS="$(mktemp)"
+    export UPDATED_DIRS_AND_MOUNTS
+    while IFS="" read -r mountpoint
+    do
+        new_mountpoint=""
+        # Split LOWER_DIRS into lines, then read each line in a loop
+        echo "$LOWER_DIRS" | tr ':' '\n' | while IFS="" read -r lower_dir
+        do
+            
+            # Form the new mountpoint
+            temp_mountpoint="$lower_dir/upperdir$mountpoint"
+            
+            # Check if the new mountpoint is a directory and is non-empty
+            if [ ! -d "$temp_mountpoint" ] || [ -z "$(find "$temp_mountpoint" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+                new_mountpoint="$mountpoint"
+            else
+                new_mountpoint="$new_mountpoint$temp_mountpoint:$mountpoint"
+            fi
+            echo "$new_mountpoint" >> "$UPDATED_DIRS_AND_MOUNTS"
+
+        done
+    done <"$DIRS_AND_MOUNTS"
+    cat $UPDATED_DIRS_AND_MOUNTS
+
+    # mv "$UPDATED_DIRS_AND_MOUNTS" "$DIRS_AND_MOUNTS"  # replace DIRS_AND_MOUNTS with the updated list
+
     # we will overlay-mount each root directory separately (instead of all at once) because some directories cannot be overlayed
     # so we set up the mount points now
     #
@@ -70,12 +97,15 @@ try() {
     # then we want to exclude the root partition "/"
     while IFS="" read -r mountpoint
     do
+        echo $mountpoint
         ## Only make the directory if the original is a directory too
         if [ -d "$mountpoint" ]
         then
             mkdir -p "${SANDBOX_DIR}/upperdir/${mountpoint}" "${SANDBOX_DIR}/workdir/${mountpoint}" "${SANDBOX_DIR}/temproot/${mountpoint}"
         fi
     done <"$DIRS_AND_MOUNTS"
+    echo "---"
+    ls "${SANDBOX_DIR}/temproot/${mountpoint}"
 
     mount_and_execute="$(mktemp)"
     chroot_executable="$(mktemp)"
@@ -94,10 +124,16 @@ TRY_COMMAND="$TRY_COMMAND($0)"
 ## A wrapper of `mount -t overlay` to have cleaner looking code
 make_overlay() {
     sandbox_dir="$1"
-    lowerdir="$2"
+    lowerdirs="$2"
     mountpoint="$3"
-    mount -t overlay overlay -o userxattr -o "lowerdir=$lowerdir,upperdir=$sandbox_dir/upperdir/$mountpoint,workdir=$sandbox_dir/workdir/$mountpoint" "$sandbox_dir/temproot/$mountpoint"
+    # echo "-"$lowerdirs
+    ls 
+
+    echo mount -t overlay overlay -o userxattr -o "lowerdir=$lowerdirs,upperdir=$sandbox_dir/upperdir/$mountpoint,workdir=$sandbox_dir/workdir/$mountpoint" "$sandbox_dir/temproot/$mountpoint"
+    # exit
+    mount -t overlay overlay -o userxattr -o "lowerdir=$lowerdirs,upperdir=$sandbox_dir/upperdir/$mountpoint,workdir=$sandbox_dir/workdir/$mountpoint" "$sandbox_dir/temproot/$mountpoint"
 }
+
 
 devices_to_mount="tty null zero full random urandom"
 
@@ -138,24 +174,29 @@ then
 fi
 
 # actually mount the overlays
-for mountpoint in $(cat "$DIRS_AND_MOUNTS")
+for mountpoint in $(cat "$UPDATED_DIRS_AND_MOUNTS")
 do
+    # echo $mountpoint
+    pure_mountpoint=$(echo "$mountpoint" | awk -F':' '{print $NF}')
+
+    # echo pure $pure_mountpoint
+
     ## We are not interested in mounts that are not directories
-    if ! [ -d "$mountpoint" ]
+    if ! [ -d "$pure_mountpoint" ]
     then
         continue
     fi
 
     ## Don't do anything for the root
     ##   and skip if it is /dev or /proc, we will mount it later
-    if [ "$mountpoint" = "/" ] ||
-        [ "$mountpoint" = "/dev" ] || [ "$mountpoint" = "/proc" ]
+    if [ "$pure_mountpoint" = "/" ] ||
+        [ "$pure_mountpoint" = "/dev" ] || [ "$pure_mountpoint" = "/proc" ]
     then
         continue
     fi
 
     # Try mounting everything normally
-    make_overlay "$SANDBOX_DIR" "/$mountpoint" "$mountpoint" 2>>"$try_mount_log"
+    make_overlay "$SANDBOX_DIR" "$mountpoint" "$pure_mountpoint" 2>>"$try_mount_log"
     # If mounting everything normally fails, we try using either using mergerfs or unionfs to mount them.
     if [ "$?" -ne 0 ]
     then
@@ -476,18 +517,18 @@ error() {
 
 usage() {
     cat >&2 <<EOF
-Usage: $TRY_COMMAND [-nvhy] [-i PATTERN] [-D DIR] [-U PATH] CMD [ARG ...]
+Usage: $TRY_COMMAND [-nvhy] [-i PATTERN] [-D DIR] [-U PATH] [-L "dir1:dir2:..."] CMD [ARG ...]
 
-  -n                don't prompt for commit
-  -y                assume yes to all prompts (implies -n is not used)
-  -i PATTERN        ignore paths that match PATTERN on summary and commit
-  -D DIR            work in DIR (implies -n)
-  -U PATH           path to unionfs helper (e.g., mergerfs, unionfs-fuse)
+  -n                 don't prompt for commit
+  -y                 assume yes to all prompts (implies -n is not used)
+  -i PATTERN         ignore paths that match PATTERN on summary and commit
+  -D DIR             work in DIR (implies -n)
+  -U PATH            path to unionfs helper (e.g., mergerfs, unionfs-fuse)
+  -L "dir1:dir2:..." specify multiple lower directories to merge (colon-separated)
 
-  -v                show version information (and exit)
-  -h                show this usage message (and exit)
-
-
+  -v                 show version information (and exit)
+  -h                 show this usage message (and exit)
+  
 Subcommands:
   $TRY_COMMAND summary DIR   show the summary for the overlay in DIR
   $TRY_COMMAND commit DIR    commit the overlay in DIR
@@ -508,7 +549,7 @@ NO_COMMIT="interactive"
 # Includes all patterns given using the `-i` flag; will be used with `grep -f`
 IGNORE_FILE="$(mktemp)"
 
-while getopts ":yvnhi:D:U:" opt
+while getopts ":yvnhi:D:U:L:" opt
 do
     case "$opt" in
         (y)   NO_COMMIT="commit";;
@@ -520,6 +561,7 @@ do
               fi
               SANDBOX_DIR="$OPTARG"
               NO_COMMIT="quiet";;
+        (L)   LOWER_DIRS="$OPTARG";;
         (v)   echo "$TRY_COMMAND version $TRY_VERSION" >&2
               exit 0;;
         (U)   if ! [ -x "$OPTARG" ]

--- a/try
+++ b/try
@@ -45,7 +45,7 @@ try() {
     fi
 
     ## Make any directories that don't already exist, this is OK to do here
-    ##  because we have already checked if it valid.
+    ## because we have already checked if it valid.
     export SANDBOX_DIR
     mkdir -p "$SANDBOX_DIR/upperdir" "$SANDBOX_DIR/workdir" "$SANDBOX_DIR/temproot"
 
@@ -56,32 +56,35 @@ try() {
     findmnt --real -r -o target -n >>"$DIRS_AND_MOUNTS"
     sort -u -o "$DIRS_AND_MOUNTS" "$DIRS_AND_MOUNTS"
 
-    # Update DIRS_AND_MOUNTS based on LOWER_DIRS
+    # Calculate UPDATED_DIRS_AND_MOUNTS that contains the merge arguments in LOWER_DIRS 
     UPDATED_DIRS_AND_MOUNTS="$(mktemp)"
     export UPDATED_DIRS_AND_MOUNTS
     while IFS="" read -r mountpoint
     do
         new_mountpoint=""
-        # Split LOWER_DIRS into lines, then read each line in a loop
-        echo "$LOWER_DIRS" | tr ':' '\n' | while IFS="" read -r lower_dir
+        temp_file=$(mktemp)
+        echo "$LOWER_DIRS" | tr ':' '\n' > "$temp_file" # Split LOWER_DIRS into lines
+        
+        while IFS="" read -r lower_dir
         do
-            
-            # Form the new mountpoint
             temp_mountpoint="$lower_dir/upperdir$mountpoint"
-            
             # Check if the new mountpoint is a directory and is non-empty
-            if [ ! -d "$temp_mountpoint" ] || [ -z "$(find "$temp_mountpoint" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
-                new_mountpoint="$mountpoint"
-            else
-                new_mountpoint="$new_mountpoint$temp_mountpoint:$mountpoint"
+            if [ -d "$temp_mountpoint" ] && [ "$(find "$temp_mountpoint" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+                if [ -n "$new_mountpoint" ]; then
+                    new_mountpoint="$new_mountpoint:$temp_mountpoint" # If new_mountpoint is not empty, append : and the temp_mountpoint
+                else
+                    new_mountpoint="$temp_mountpoint" # If new_mountpoint is empty, just set it to temp_mountpoint
+                fi
             fi
-            echo "$new_mountpoint" >> "$UPDATED_DIRS_AND_MOUNTS"
+        done < "$temp_file"
 
-        done
+        rm "$temp_file" # Clean up the temporary file
+
+        new_mountpoint="${new_mountpoint:+$new_mountpoint:}$mountpoint" # Add the original mountpoint at the end
+
+        echo "$new_mountpoint" >> "$UPDATED_DIRS_AND_MOUNTS" # Write the new mountpoint to the updated list
+
     done <"$DIRS_AND_MOUNTS"
-    cat $UPDATED_DIRS_AND_MOUNTS
-
-    # mv "$UPDATED_DIRS_AND_MOUNTS" "$DIRS_AND_MOUNTS"  # replace DIRS_AND_MOUNTS with the updated list
 
     # we will overlay-mount each root directory separately (instead of all at once) because some directories cannot be overlayed
     # so we set up the mount points now
@@ -97,15 +100,12 @@ try() {
     # then we want to exclude the root partition "/"
     while IFS="" read -r mountpoint
     do
-        echo $mountpoint
         ## Only make the directory if the original is a directory too
         if [ -d "$mountpoint" ]
         then
             mkdir -p "${SANDBOX_DIR}/upperdir/${mountpoint}" "${SANDBOX_DIR}/workdir/${mountpoint}" "${SANDBOX_DIR}/temproot/${mountpoint}"
         fi
     done <"$DIRS_AND_MOUNTS"
-    echo "---"
-    ls "${SANDBOX_DIR}/temproot/${mountpoint}"
 
     mount_and_execute="$(mktemp)"
     chroot_executable="$(mktemp)"
@@ -126,11 +126,6 @@ make_overlay() {
     sandbox_dir="$1"
     lowerdirs="$2"
     mountpoint="$3"
-    # echo "-"$lowerdirs
-    ls 
-
-    echo mount -t overlay overlay -o userxattr -o "lowerdir=$lowerdirs,upperdir=$sandbox_dir/upperdir/$mountpoint,workdir=$sandbox_dir/workdir/$mountpoint" "$sandbox_dir/temproot/$mountpoint"
-    # exit
     mount -t overlay overlay -o userxattr -o "lowerdir=$lowerdirs,upperdir=$sandbox_dir/upperdir/$mountpoint,workdir=$sandbox_dir/workdir/$mountpoint" "$sandbox_dir/temproot/$mountpoint"
 }
 
@@ -176,10 +171,7 @@ fi
 # actually mount the overlays
 for mountpoint in $(cat "$UPDATED_DIRS_AND_MOUNTS")
 do
-    # echo $mountpoint
     pure_mountpoint=$(echo "$mountpoint" | awk -F':' '{print $NF}')
-
-    # echo pure $pure_mountpoint
 
     ## We are not interested in mounts that are not directories
     if ! [ -d "$pure_mountpoint" ]

--- a/try
+++ b/try
@@ -68,18 +68,14 @@ try() {
         for lower_dir in $LOWER_DIRS
         do
             temp_mountpoint="$lower_dir/upperdir$mountpoint"
-            # Check if the new mountpoint is a directory and is non-empty
-            if [ -d "$temp_mountpoint" ] && [ "$(find "$temp_mountpoint" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
-                if [ -n "$new_mountpoint" ]; then
-                    # If new_mountpoint is not empty, append : and the temp_mountpoint
-                    new_mountpoint="$new_mountpoint:$temp_mountpoint"
-                else
-                     # If new_mountpoint is empty, just set it to temp_mountpoint
-                    new_mountpoint="$temp_mountpoint"
-                fi
+            if [ -n "$new_mountpoint" ]; then
+                # If new_mountpoint is not empty, append : and the temp_mountpoint
+                new_mountpoint="$new_mountpoint:$temp_mountpoint"
+            else
+                # If new_mountpoint is empty, just set it to temp_mountpoint
+                new_mountpoint="$temp_mountpoint"
             fi
         done
-
         IFS=$OLDIFS
         # Add the original mountpoint at the end
         new_mountpoint="${new_mountpoint:+$new_mountpoint:}$mountpoint"

--- a/try
+++ b/try
@@ -122,8 +122,8 @@ TRY_COMMAND="$TRY_COMMAND($0)"
 make_overlay() {
     sandbox_dir="$1"
     lowerdirs="$2"
-    mountpoint="$3"
-    mount -t overlay overlay -o userxattr -o "lowerdir=$lowerdirs,upperdir=$sandbox_dir/upperdir/$mountpoint,workdir=$sandbox_dir/workdir/$mountpoint" "$sandbox_dir/temproot/$mountpoint"
+    overlay_mountpoint="$3"
+    mount -t overlay overlay -o userxattr -o "lowerdir=$lowerdirs,upperdir=$sandbox_dir/upperdir/$overlay_mountpoint,workdir=$sandbox_dir/workdir/$overlay_mountpoint" "$sandbox_dir/temproot/$overlay_mountpoint"
 }
 
 
@@ -182,7 +182,6 @@ do
     (/|/dev|/proc) continue;;
     esac
 
-
     # Try mounting everything normally
     make_overlay "$SANDBOX_DIR" "$mountpoint" "$pure_mountpoint" 2>>"$try_mount_log"
     # If mounting everything normally fails, we try using either using mergerfs or unionfs to mount them.
@@ -209,9 +208,7 @@ do
             ## Create a union directory
             "$UNION_HELPER" $mountpoint $merger_dir 2>>"$try_mount_log" ||
                 printf "%s: Warning: Failed mounting $mountpoint via $UNION_HELPER, see \"$try_mount_log\"\n" "$TRY_COMMAND" >&2
-
-            ## Make the overlay on the union directory which works as a lowerdir for overlay
-            make_overlay "$SANDBOX_DIR" "$merger_dir" "$mountpoint" 2>>"$try_mount_log" ||
+            make_overlay "$SANDBOX_DIR" "$merger_dir" "$pure_mountpoint" 2>>"$try_mount_log" ||
             printf "%s: Warning: Failed mounting $mountpoint as an overlay via $UNION_HELPER, see \"$try_mount_log\"\n" "$TRY_COMMAND" >&2
         fi
     fi

--- a/try
+++ b/try
@@ -68,7 +68,8 @@ try() {
         for lower_dir in $LOWER_DIRS
         do
             temp_mountpoint="$lower_dir/upperdir$mountpoint"
-            if [ -n "$new_mountpoint" ]; then
+            if [ -n "$new_mountpoint" ]
+            then
                 # If new_mountpoint is not empty, append : and the temp_mountpoint
                 new_mountpoint="$new_mountpoint:$temp_mountpoint"
             else
@@ -176,10 +177,9 @@ do
         continue
     fi
 
-    ## Don't do anything for the root
-    ## and skip if it is /dev or /proc, we will mount it later
+    ## Don't do anything for the root and skip if it is /dev or /proc, we will mount it later
     case "$pure_mountpoint" in
-    (/|/dev|/proc) continue;;
+        (/|/dev|/proc) continue;;
     esac
 
     # Try mounting everything normally
@@ -503,17 +503,17 @@ error() {
 
 usage() {
     cat >&2 <<EOF
-Usage: $TRY_COMMAND [-nvhyx] [-i PATTERN] [-D DIR] [-U PATH] [-L "dir1:dir2:..."] CMD [ARG ...]
+Usage: $TRY_COMMAND [-nvhyx] [-i PATTERN] [-D DIR] [-U PATH] [-L dir1:dir2:...] CMD [ARG ...]
 
   -n                don't commit or prompt for commit (overrides -y)
   -y                assume yes to all prompts (overrides -n)
   -x                prevent network access (by unsharing the network namespace)
   -i PATTERN        ignore paths that match PATTERN on summary and commit
-  -D DIR             work in DIR (implies -n)
-  -U PATH            path to unionfs helper (e.g., mergerfs, unionfs-fuse)
-  -L "dir1:dir2:..." specify multiple lower directories to merge (colon-separated, implies -n)
-  -v                 show version information (and exit)
-  -h                 show this usage message (and exit)
+  -D DIR            work in DIR (implies -n)
+  -U PATH           path to unionfs helper (e.g., mergerfs, unionfs-fuse)
+  -L dir1:dir2:...  specify multiple lower directories to merge (colon-separated, implies -n)
+  -v                show version information (and exit)
+  -h                show this usage message (and exit)
 
 Subcommands:
   $TRY_COMMAND summary DIR   show the summary for the overlay in DIR
@@ -548,8 +548,9 @@ do
               fi
               SANDBOX_DIR="$OPTARG"
               NO_COMMIT="quiet";;
-        (L)   if [ -n "$LOWER_DIRS" ]; then
-                  error "the -L option has been specified multiple times." 2
+        (L)   if [ -n "$LOWER_DIRS" ]
+              then
+                  error "the -L option has been specified multiple times" 2
               fi
               LOWER_DIRS="$OPTARG"
               NO_COMMIT="quiet";;

--- a/try
+++ b/try
@@ -509,7 +509,7 @@ Usage: $TRY_COMMAND [-nvhy] [-i PATTERN] [-D DIR] [-U PATH] [-L "dir1:dir2:..."]
   -i PATTERN         ignore paths that match PATTERN on summary and commit
   -D DIR             work in DIR (implies -n)
   -U PATH            path to unionfs helper (e.g., mergerfs, unionfs-fuse)
-  -L "dir1:dir2:..." specify multiple lower directories to merge (colon-separated)
+  -L "dir1:dir2:..." specify multiple lower directories to merge (colon-separated, implies -n)
 
   -v                 show version information (and exit)
   -h                 show this usage message (and exit)
@@ -546,7 +546,8 @@ do
               fi
               SANDBOX_DIR="$OPTARG"
               NO_COMMIT="quiet";;
-        (L)   LOWER_DIRS="$OPTARG";;
+        (L)   LOWER_DIRS="$OPTARG"
+              NO_COMMIT="quiet";;
         (v)   echo "$TRY_COMMAND version $TRY_VERSION" >&2
               exit 0;;
         (U)   if ! [ -x "$OPTARG" ]

--- a/try
+++ b/try
@@ -62,29 +62,28 @@ try() {
     while IFS="" read -r mountpoint
     do
         new_mountpoint=""
-        temp_file=$(mktemp)
-        echo "$LOWER_DIRS" | tr ':' '\n' > "$temp_file" # Split LOWER_DIRS into lines
 
-        while IFS="" read -r lower_dir
+        IFS=":"
+
+        for lower_dir in $LOWER_DIRS
         do
             temp_mountpoint="$lower_dir/upperdir$mountpoint"
             # Check if the new mountpoint is a directory and is non-empty
             if [ -d "$temp_mountpoint" ] && [ "$(find "$temp_mountpoint" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
                 if [ -n "$new_mountpoint" ]; then
-                    new_mountpoint="$new_mountpoint:$temp_mountpoint" # If new_mountpoint is not empty, append : and the temp_mountpoint
+                    # If new_mountpoint is not empty, append : and the temp_mountpoint
+                    new_mountpoint="$new_mountpoint:$temp_mountpoint"
                 else
-                    new_mountpoint="$temp_mountpoint" # If new_mountpoint is empty, just set it to temp_mountpoint
+                     # If new_mountpoint is empty, just set it to temp_mountpoint
+                    new_mountpoint="$temp_mountpoint"
                 fi
             fi
-        done < "$temp_file"
-
-        rm "$temp_file" # Clean up the temporary file
-
-        new_mountpoint="${new_mountpoint:+$new_mountpoint:}$mountpoint" # Add the original mountpoint at the end
-
-        echo "$new_mountpoint" >> "$UPDATED_DIRS_AND_MOUNTS" # Write the new mountpoint to the updated list
-
+        done
+        # Add the original mountpoint at the end
+        new_mountpoint="${new_mountpoint:+$new_mountpoint:}$mountpoint"
+        echo "$new_mountpoint" >> "$UPDATED_DIRS_AND_MOUNTS"
     done <"$DIRS_AND_MOUNTS"
+
 
     # we will overlay-mount each root directory separately (instead of all at once) because some directories cannot be overlayed
     # so we set up the mount points now

--- a/try
+++ b/try
@@ -546,7 +546,11 @@ do
               fi
               SANDBOX_DIR="$OPTARG"
               NO_COMMIT="quiet";;
-        (L)   LOWER_DIRS="$OPTARG"
+        (L)   if [ -n "$LOWER_DIRS" ]; then
+                  error "the -L option has been specified multiple times." 2
+                  exit 1
+              fi
+              LOWER_DIRS="$OPTARG"
               NO_COMMIT="quiet";;
         (v)   echo "$TRY_COMMAND version $TRY_VERSION" >&2
               exit 0;;

--- a/try
+++ b/try
@@ -62,7 +62,7 @@ try() {
     while IFS="" read -r mountpoint
     do
         new_mountpoint=""
-
+        OLDIFS=$IFS
         IFS=":"
 
         for lower_dir in $LOWER_DIRS
@@ -79,6 +79,8 @@ try() {
                 fi
             fi
         done
+
+        IFS=$OLDIFS
         # Add the original mountpoint at the end
         new_mountpoint="${new_mountpoint:+$new_mountpoint:}$mountpoint"
         echo "$new_mountpoint" >> "$UPDATED_DIRS_AND_MOUNTS"
@@ -170,7 +172,7 @@ fi
 # actually mount the overlays
 for mountpoint in $(cat "$UPDATED_DIRS_AND_MOUNTS")
 do
-    pure_mountpoint=$(echo "$mountpoint" | awk -F':' '{print $NF}')
+    pure_mountpoint=${mountpoint##*:}
 
     ## We are not interested in mounts that are not directories
     if ! [ -d "$pure_mountpoint" ]
@@ -179,12 +181,11 @@ do
     fi
 
     ## Don't do anything for the root
-    ##   and skip if it is /dev or /proc, we will mount it later
-    if [ "$pure_mountpoint" = "/" ] ||
-        [ "$pure_mountpoint" = "/dev" ] || [ "$pure_mountpoint" = "/proc" ]
-    then
-        continue
-    fi
+    ## and skip if it is /dev or /proc, we will mount it later
+    case "$pure_mountpoint" in
+    (/|/dev|/proc) continue;;
+    esac
+
 
     # Try mounting everything normally
     make_overlay "$SANDBOX_DIR" "$mountpoint" "$pure_mountpoint" 2>>"$try_mount_log"

--- a/try
+++ b/try
@@ -548,7 +548,6 @@ do
               NO_COMMIT="quiet";;
         (L)   if [ -n "$LOWER_DIRS" ]; then
                   error "the -L option has been specified multiple times." 2
-                  exit 1
               fi
               LOWER_DIRS="$OPTARG"
               NO_COMMIT="quiet";;


### PR DESCRIPTION
This Pull Request introduces the `-L` flag to `try`, enabling the specification and merging of multiple lower directories for overlay. The lower directories are specified as a colon-separated list (`dir_1:dir_2:...:dir_n`), operating with a precedence logic where directories on the left have a higher precedence over those on the right. This feature allows users to overlay multiple directories together during the command execution within a single overlay environment.