### PR TITLE
feat(net): add option -x to unshare network

### DIFF
--- a/completions/try.bash
+++ b/completions/try.bash
@@ -17,7 +17,7 @@ _try() {
 
     case "${cmd}" in
         (try)
-            opts="-n -y -v -h -i -D -U summary commit explore"
+            opts="-n -y -v -h -x -i -D -U summary commit explore"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]]
             then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/docs/try.1.md
+++ b/docs/try.1.md
@@ -39,7 +39,7 @@ While using *try* you can choose to commit the result to the filesystem or compl
 
 -x
 
-: Prevent network access (by unsharing the network namespace.)
+: Prevent network access (by unsharing the network namespace).
 
 
 ## Options

--- a/docs/try.1.md
+++ b/docs/try.1.md
@@ -37,6 +37,10 @@ While using *try* you can choose to commit the result to the filesystem or compl
 
 : Show a usage message (and exit).
 
+-x
+
+: Unshare the network namespace.
+
 
 ## Options
 

--- a/docs/try.1.md
+++ b/docs/try.1.md
@@ -39,7 +39,7 @@ While using *try* you can choose to commit the result to the filesystem or compl
 
 -x
 
-: Unshare the network namespace.
+: Prevent network access (by unsharing the network namespace.)
 
 
 ## Options

--- a/test/network.sh
+++ b/test/network.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+TRY_TOP="${TRY_TOP:-$(git rev-parse --show-toplevel --show-superproject-working-tree)}"
+TRY="$TRY_TOP/try"
+
+# Test if network works normally
+"$TRY" curl 1.1 || return 1
+
+# Test if ping fails when network is unshared
+# curl exit code 7 means Failed to connect to host.
+"$TRY" -x curl 1.1
+if [ $? -eq 7 ]; then
+    return 0;
+else
+    return 1;
+fi

--- a/test/network.sh
+++ b/test/network.sh
@@ -4,9 +4,10 @@ TRY_TOP="${TRY_TOP:-$(git rev-parse --show-toplevel --show-superproject-working-
 TRY="$TRY_TOP/try"
 
 # Test if network works normally
+# using curl due to #131 (1.1 expands to 1.0.0.1)
 "$TRY" curl 1.1 || return 1
 
-# Test if ping fails when network is unshared
+# Test if curl fails when network is unshared
 # curl exit code 7 means Failed to connect to host.
 "$TRY" -x curl 1.1
 if [ $? -eq 7 ]; then

--- a/test/network.sh
+++ b/test/network.sh
@@ -10,8 +10,9 @@ TRY="$TRY_TOP/try"
 # Test if curl fails when network is unshared
 # curl exit code 7 means Failed to connect to host.
 "$TRY" -x curl 1.1
-if [ $? -eq 7 ]; then
-    return 0;
+if [ $? -eq 7 ]
+then
+    return 0
 else
-    return 1;
+    return 1
 fi

--- a/try
+++ b/try
@@ -233,11 +233,7 @@ EOF
     # --pid: create a new process namespace (needed fr procfs to work right)
     # --fork: necessary if we do --pid
     #         "Creation of a persistent PID namespace will fail if the --fork option is not also specified."
-    if [ -z "$EXTRA_NS" ]; then
-        unshare --mount --map-root-user --user --pid --fork "$mount_and_execute"
-    else
-        unshare --mount --map-root-user --user --pid --fork --net "$mount_and_execute"
-    fi
+    unshare --mount --map-root-user --user --pid --fork $EXTRA_NS "$mount_and_execute"
     TRY_EXIT_STATUS=$?
 
     ################################################################################
@@ -533,7 +529,7 @@ do
               fi
               UNION_HELPER="$OPTARG"
               export UNION_HELPER;;
-        (x)   EXTRA_NS="net";;
+        (x)   EXTRA_NS="--net";;
         (h|*) usage
               exit 0;;
     esac

--- a/try
+++ b/try
@@ -480,7 +480,7 @@ Usage: $TRY_COMMAND [-nvhyx] [-i PATTERN] [-D DIR] [-U PATH] CMD [ARG ...]
 
   -n                don't commit or prompt for commit (overrides -y)
   -y                assume yes to all prompts (overrides -n)
-  -x                revent network access (by unsharing the network namespace.)
+  -x                prevent network access (by unsharing the network namespace)
   -i PATTERN        ignore paths that match PATTERN on summary and commit
   -D DIR            work in DIR (implies -n)
   -U PATH           path to unionfs helper (e.g., mergerfs, unionfs-fuse)

--- a/try
+++ b/try
@@ -233,10 +233,10 @@ EOF
     # --pid: create a new process namespace (needed fr procfs to work right)
     # --fork: necessary if we do --pid
     #         "Creation of a persistent PID namespace will fail if the --fork option is not also specified."
-    if [ "$EXTRA_NS" = "net" ]; then
-        unshare --mount --map-root-user --user --pid --fork --net "$mount_and_execute"
-    else
+    if [ -z "$EXTRA_NS" ]; then
         unshare --mount --map-root-user --user --pid --fork "$mount_and_execute"
+    else
+        unshare --mount --map-root-user --user --pid --fork --net "$mount_and_execute"
     fi
     TRY_EXIT_STATUS=$?
 

--- a/try
+++ b/try
@@ -480,7 +480,7 @@ Usage: $TRY_COMMAND [-nvhyx] [-i PATTERN] [-D DIR] [-U PATH] CMD [ARG ...]
 
   -n                don't commit or prompt for commit (overrides -y)
   -y                assume yes to all prompts (overrides -n)
-  -x                unshare the network namespace
+  -x                revent network access (by unsharing the network namespace.)
   -i PATTERN        ignore paths that match PATTERN on summary and commit
   -D DIR            work in DIR (implies -n)
   -U PATH           path to unionfs helper (e.g., mergerfs, unionfs-fuse)

--- a/try
+++ b/try
@@ -233,7 +233,11 @@ EOF
     # --pid: create a new process namespace (needed fr procfs to work right)
     # --fork: necessary if we do --pid
     #         "Creation of a persistent PID namespace will fail if the --fork option is not also specified."
-    unshare --mount --map-root-user --user --pid --fork "$mount_and_execute"
+    if [ "$EXTRA_NS" = "net" ]; then
+        unshare --mount --map-root-user --user --pid --fork --net "$mount_and_execute"
+    else
+        unshare --mount --map-root-user --user --pid --fork "$mount_and_execute"
+    fi
     TRY_EXIT_STATUS=$?
 
     ################################################################################
@@ -476,10 +480,11 @@ error() {
 
 usage() {
     cat >&2 <<EOF
-Usage: $TRY_COMMAND [-nvhy] [-i PATTERN] [-D DIR] [-U PATH] CMD [ARG ...]
+Usage: $TRY_COMMAND [-nvhyx] [-i PATTERN] [-D DIR] [-U PATH] CMD [ARG ...]
 
   -n                don't commit or prompt for commit (overrides -y)
   -y                assume yes to all prompts (overrides -n)
+  -x                unshare the network namespace
   -i PATTERN        ignore paths that match PATTERN on summary and commit
   -D DIR            work in DIR (implies -n)
   -U PATH           path to unionfs helper (e.g., mergerfs, unionfs-fuse)
@@ -508,7 +513,7 @@ NO_COMMIT="interactive"
 # Includes all patterns given using the `-i` flag; will be used with `grep -f`
 IGNORE_FILE="$(mktemp)"
 
-while getopts ":yvnhi:D:U:" opt
+while getopts ":yvnhxi:D:U:" opt
 do
     case "$opt" in
         (y)   NO_COMMIT="commit";;
@@ -528,6 +533,7 @@ do
               fi
               UNION_HELPER="$OPTARG"
               export UNION_HELPER;;
+        (x)   EXTRA_NS="net";;
         (h|*) usage
               exit 0;;
     esac


### PR DESCRIPTION
This PR adds an option `-x` to unshare the network by adding `--net` to the first unshare invocation.

- [x] add option to try
- [x] add to unit test

```
eric@ide0:~/try$ ./try ip --brief link
lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
ens18            UP             ce:b8:f6:2a:67:af <BROADCAST,MULTICAST,UP,LOWER_UP>
eric@ide0:~/try$ ./try -x ip --brief link
lo               DOWN           00:00:00:00:00:00 <LOOPBACK>
```

Note: I would use `ping -c1 1.1` instead of `curl 1.1` but #131 

Closes #127 