### PR TITLE
fix(ci): disable fail fast

### DIFF
--- a/.github/workflows/vagrant.yaml
+++ b/.github/workflows/vagrant.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   vagrant:
     strategy:
+      fail-fast: false
       matrix:
         vagrant_target:
           - debian


### PR DESCRIPTION
Currently when one of the vagrant tests fail, all other tests will exit.
Due to #128, vagrant builds are now failing randomly. This PR allows the rest of the tests to be completed even when one fails. We can later re-run the failed test.