### PR TITLE
fix(ci): pin macOS runner version

### DIFF
--- a/.github/workflows/vagrant.yaml
+++ b/.github/workflows/vagrant.yaml
@@ -19,7 +19,7 @@ jobs:
           - debianlvm
           - rocky9
           - fedora33
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/vagrant.yaml
+++ b/.github/workflows/vagrant.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   vagrant:
     strategy:
+      fail-fast: false
       matrix:
         vagrant_target:
           - debian


### PR DESCRIPTION
it seems like macos-12 has a higher chance of having our vagrant builds pass. This PR pins the runner version to macos-12