### PR TITLE
Add minimal kernel ver to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To run `try`'s test suite (`test/run_tests.sh`), you will need:
 
 *Note that try will only work on [Linux
 5.11](https://github.com/torvalds/linux/commit/92dbc9dedccb9759c7f9f2f0ae6242396376988f)
-or higher for overlayfs to work in a user namespace*
+or higher for overlayfs to work in a user namespace.*
 
 ### Installing
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ To run `try`'s test suite (`test/run_tests.sh`), you will need:
 * `Rocky 9 5.14.0-284.11.1.el9_2`
 * `SteamOS 3.4.8 5.13.0-valve36-1-neptune`
 
+*Note that try will only work on [Linux
+5.11](https://github.com/torvalds/linux/commit/92dbc9dedccb9759c7f9f2f0ae6242396376988f)
+or higher for overlayfs to work in a user namespace*
+
 ### Installing
 
 You only need the [`try` script](https://raw.githubusercontent.com/binpash/try/main/try), which you can download by cloning this repository:


### PR DESCRIPTION
overlayfs in user namespace is only made available in [Linux 5.11](https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.11) via Commit [92dbc9dedccb9759c7f9f2f0ae6242396376988f](https://github.com/torvalds/linux/commit/92dbc9dedccb9759c7f9f2f0ae6242396376988f#diff-8de54ea5856f1707bab13745775c54edb26bc3f5a97eafe3220d66ded0d29c53).

One common case is users using Debian 11 (bullseye), which is still on Linux 5.10.