### PR TITLE
perf: Replace subshell with POSIX Parameter expansion

### DIFF
--- a/try
+++ b/try
@@ -8,8 +8,7 @@
 # https://github.com/binpash/try
 
 TRY_VERSION="0.2.0"
-TRY_COMMAND="$(basename "$0")"
-export TRY_COMMAND
+export TRY_COMMAND="${0##*/}"
 
 # exit status invariants
 #

--- a/try
+++ b/try
@@ -8,7 +8,8 @@
 # https://github.com/binpash/try
 
 TRY_VERSION="0.2.0"
-export TRY_COMMAND="${0##*/}"
+TRY_COMMAND="${0##*/}"
+export TRY_COMMAND
 
 # exit status invariants
 #


### PR DESCRIPTION
This replaces a subshell that called out to `basename` with [Parameter Expansion specified by POSIX](https://pubs.opengroup.org/onlinepubs/009604499/utilities/xcu_chap02.html). As a result, the `export` variable no longer has to be on a separate line (to prevent masking errors).