### PR TITLE
remove unnecessary sync

### DIFF
--- a/try
+++ b/try
@@ -249,7 +249,6 @@ unshare --root="$SANDBOX_DIR/temproot" /bin/sh "$chroot_executable"
 exitcode="$?"
 
 # unmount the devices
-sync
 unmount_devices "$SANDBOX_DIR"
 
 exit $exitcode


### PR DESCRIPTION
`sync` before unmounting the device files after unshare may be unnecessary and adds overtime.
this PR removes the `sync`.