### PR TITLE
use debian12 as vagrant runner

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
     debianrustup.vm.provision "file", source: "./", destination: "/home/vagrant/try"
     debianrustup.vm.provision "shell", privileged: false, inline: "
       sudo apt-get update
-      sudo apt-get install -y curl attr pandoc gcc make autoconf
+      sudo apt-get install -y curl attr pandoc gcc make autoconf mergerfs
       sudo chown -R vagrant:vagrant try
       cd try
       mkdir rustup

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure("2") do |config|
 
   # Regular debian testing box
   config.vm.define "debian" do |debian|
-    debian.vm.box = "debian/testing64"
+    debian.vm.box = "generic/debian12"
     debian.vm.provision "file", source: "./", destination: "/home/vagrant/try"
     debian.vm.provision "shell", privileged: false, inline: "
       sudo apt-get update
@@ -26,7 +26,7 @@ Vagrant.configure("2") do |config|
 
   # Regular debian testing box but we try the rustup oneliner
   config.vm.define "debianrustup" do |debianrustup|
-    debianrustup.vm.box = "debian/testing64"
+    debianrustup.vm.box = "generic/debian12"
     debianrustup.vm.provision "file", source: "./", destination: "/home/vagrant/try"
     debianrustup.vm.provision "shell", privileged: false, inline: "
       sudo apt-get update
@@ -50,7 +50,7 @@ Vagrant.configure("2") do |config|
 
   # Regular debian testing box with LVM
   config.vm.define "debianlvm" do |debianlvm|
-    debianlvm.vm.box = "debian/testing64"
+    debianlvm.vm.box = "generic/debian12"
     debianlvm.vm.provision "file", source: "./", destination: "/home/vagrant/try"
     debianlvm.vm.provision "shell", privileged: false, inline: "
       sudo apt-get update

--- a/test/toplevel-perms.sh
+++ b/test/toplevel-perms.sh
@@ -34,7 +34,7 @@ cd "$try_workspace" || exit 9
 touch test
 
 cmd="$(mktemp)"
-echo "find / -maxdepth 1 -print0 | xargs -0 ls -ld | awk '{print substr(\$1, 1, 10), \$9, \$10, \$11}' | grep -v 'proc' | grep -v 'swap'" > "$cmd"
+echo "find / -maxdepth 1 -print0 | xargs -0 ls -ld | awk '{print substr(\$1, 1, 10), \$9, \$10, \$11}' | grep -v 'proc' | grep -v 'swap' | grep -v 'vmlinuz' | grep -v 'initrd'" > "$cmd"
 # Use this after gidmapper to show user and group ownership
 #echo "find / -maxdepth 1 -print0 | xargs -0 ls -ld | awk '{print substr(\$1, 1, 10), \$3, \$4, \$9, \$10, \$11}' | grep -v 'proc' | grep -v 'swap'" > "$cmd"
 


### PR DESCRIPTION
for some reason the current debian box we're using (debian/testing64) is broken, this PR changes it to use (generic/debian12) box, and because of box differences, we're also using mergerfs on the debianrustup test.