### PR TITLE
CI fix, attempt 2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,8 @@ jobs:
       - name: Debug unshare install
         run: |
           echo unshare is at $(which unshare)
-          unshare --mount --user --pid --fork -- ls
+          findmnt
+          unshare --mount --propagation unchanged --user --pid --fork -- ls
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,12 +19,6 @@ jobs:
         run: |
           sudo apt-get install util-linux expect mergerfs attr pandoc
 
-      - name: Debug unshare install
-        run: |
-          echo unshare is at $(which unshare)
-          findmnt
-          unshare --mount --propagation unchanged --user --pid --fork -- ls
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -56,6 +50,10 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
+      - name: Allow unprivileged user namespaces (for Ubuntu 24.04)
+        run: |
+          sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Install dependencies
         run: |
           sudo apt-get install expect mergerfs attr pandoc
@@ -98,6 +96,10 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
+      - name: Allow unprivileged user namespaces (for Ubuntu 24.04)
+        run: |
+          sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Install dependencies
         run: |
           sudo apt-get install expect mergerfs attr pandoc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,10 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
+      - name: Allow unprivileged user namespaces (for Ubuntu 24.04)
+        run: |
+          sudo sysctl kernel.apparmor_restrict_unprivileged_userns=0
+
       - name: Install dependencies
         run: |
           sudo apt-get install util-linux expect mergerfs attr pandoc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Debug unshare install
         run: |
           echo unshare is at $(which unshare)
-          unshare --mount --map-root-user --user --pid --fork -- ls
+          unshare --mount --user --pid --fork -- ls
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/configure.ac
+++ b/configure.ac
@@ -131,7 +131,7 @@ fi
 
 TRY_REQUIRE_PROG([readlink])
 TRY_REQUIRE_PROG([unshare], [for unshare], [
-res=$(unshare --mount --map-root-user --user --pid --fork -- ls $PWD/try 2>/dev/null)
+res=$(unshare --mount --propagation unchanged --user --pid --fork -- ls $PWD/try 2>/dev/null)
 ], [
 test "$?" != 0 || test "$res" != "$PWD/try"
 ], [], [could not run unshare])

--- a/configure.ac
+++ b/configure.ac
@@ -131,7 +131,7 @@ fi
 
 TRY_REQUIRE_PROG([readlink])
 TRY_REQUIRE_PROG([unshare], [for unshare], [
-res=$(unshare --mount --propagation unchanged --user --pid --fork -- ls $PWD/try 2>/dev/null)
+res=$(unshare --mount --map-root-user --user --pid --fork -- ls $PWD/try 2>/dev/null)
 ], [
 test "$?" != 0 || test "$res" != "$PWD/try"
 ], [], [could not run unshare])


### PR DESCRIPTION
The unshare call failing in CI on Ubuntu is likely due to `--map-root-user`; will try without it.