### PR TITLE
no findmnt

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install util-linux expect mergerfs attr pandoc
+          sudo apt-get install expect mergerfs attr pandoc
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ commands that you don't already trust on your system, (i.e. network calls are al
 
 `try` relies on the following Debian packages
 
-* `util-linux` (for standard Linux utilities, `findmnt`)
 * `attr` (for `getfattr`)
 * `pandoc` and `autoconf` (if working from a GitHub clone)
 

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,6 @@ pkgs.mkShell {
     expect
     mergerfs
     attr
-    util-linux
     time
     shellcheck
   ];

--- a/shell.nix
+++ b/shell.nix
@@ -5,6 +5,7 @@ pkgs.mkShell {
     expect
     mergerfs
     attr
+    util-linux
     time
     shellcheck
   ];

--- a/test/missing_unionfs_mergerfs.sh
+++ b/test/missing_unionfs_mergerfs.sh
@@ -42,7 +42,6 @@ run_nix() {
     pkgs.mkShell {
         buildInputs = with pkgs; [
             attr
-            util-linux
         ];
     }
 EOF

--- a/try
+++ b/try
@@ -217,6 +217,8 @@ do
         ##               We should try to investigate either:
         ##               1. Not doing another overlay if we have done it for a parent directory (we can keep around a list of overlays and skip if we are in a child)
         ##               2. Do one unionfs+overlay at the root `/` once and be done with it!
+        ##
+        ## EZ 2025-01-10 We have removed findmnt since it is unneccessary #189
 
         if [ -z "$UNION_HELPER" ]
         then

--- a/try
+++ b/try
@@ -108,13 +108,6 @@ try() {
     #
     # KK 2023-06-29 This approach (of mounting each root directory separately) was necessary because we could not mount `/` in an overlay.
     #               However, this might be solvable using mergerfs/unionfs, allowing us to mount an overlay on a unionfs of the `/` once.
-    #
-    # findmnt
-    # --real: only list real filesystems
-    # -n: no header
-    # -r: raw output
-    # -o target: only print the mount target
-    # then we want to exclude the root partition "/"
     while IFS="" read -r mountpoint
     do
         ## Only make the directory if the original is a directory too

--- a/try
+++ b/try
@@ -26,11 +26,6 @@ export TRY_COMMAND
 try() {
     START_DIR="$PWD"
 
-    if ! command -v findmnt >/dev/null
-    then
-        error "findmnt not found, please install util-linux" "$TRY_COMMAND" 2
-    fi
-
     if [ "$SANDBOX_DIR" ]
     then
         ## If the name of a sandbox is given then we need to exit prematurely if its directory doesn't exist
@@ -78,7 +73,6 @@ try() {
     DIRS_AND_MOUNTS="$SANDBOX_DIR"/mounts
     export DIRS_AND_MOUNTS
     find / -maxdepth 1 >"$DIRS_AND_MOUNTS"
-    findmnt --real -r -o target -n >>"$DIRS_AND_MOUNTS"
     sort -u -o "$DIRS_AND_MOUNTS" "$DIRS_AND_MOUNTS"
 
     # Calculate UPDATED_DIRS_AND_MOUNTS that contains the merge arguments in LOWER_DIRS


### PR DESCRIPTION
In the past we added the ability for try to go over findmnt's results and mount non-root directories that are mounts, however this doesn't allow their parent directory to be mounted without mergerfs, essentially rendering it useless.

This PR removes the code that uses findmnt, and also updates the docs and CI scripts to remove util-linux as that dep's only use was to provide findmnt. 