### PR TITLE
Fix premature ignore file move

### DIFF
--- a/try
+++ b/try
@@ -78,10 +78,6 @@ try() {
     ## because we have already checked if it valid.
     export SANDBOX_DIR
 
-    # We created "$IGNORE_FILE" up front, but now we can stash it in the sandbox.
-    mv "$IGNORE_FILE" "$SANDBOX_DIR"/ignore
-    IGNORE_FILE="$SANDBOX_DIR"/ignore
-
     try_mount_log="$SANDBOX_DIR"/mount.log
     export try_mount_log
 
@@ -94,6 +90,10 @@ try() {
         echo "consider docker volumes if you want persistence" >> "$try_mount_log"
         mount -t tmpfs tmpfs "$SANDBOX_DIR"
     fi
+
+    # Move ignore patterns after any tmpfs mount; mounting SANDBOX_DIR hides prior contents.
+    mv "$IGNORE_FILE" "$SANDBOX_DIR"/ignore
+    IGNORE_FILE="$SANDBOX_DIR"/ignore
 
     mkdir -p "$SANDBOX_DIR/upperdir" "$SANDBOX_DIR/workdir" "$SANDBOX_DIR/temproot"
 


### PR DESCRIPTION
Inside a container (using `tmpfs`), the ignore file is moved inside the sandbox directory _before_ mounting. Mounting then hides the file, so later `grep -v -f "$ignore_file"` fails.

Inside a container:
```sh
root@fac46d5259bb:/app# ./try echo hello
hello
grep: /tmp/tmp.pfBSmAqO3o.try-1772248742591/ignore: No such file or directory
```