### PR TITLE
Make unprivileged run less noisy

### DIFF
--- a/try
+++ b/try
@@ -325,7 +325,7 @@ EOF
         pure_mountpoint=${mountpoint##*:}
         if [  -L "$pure_mountpoint" ]
         then
-            rm "${SANDBOX_DIR}/temproot/${mountpoint}"
+            rm "${SANDBOX_DIR}/temproot/${mountpoint}" 2>"$try_mount_log"
         fi
     done <"$DIRS_AND_MOUNTS"
 


### PR DESCRIPTION
This makes the permission denied messages from mount and unshare more visible.